### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/_sources/background.rst.txt
+++ b/_sources/background.rst.txt
@@ -2,7 +2,7 @@ Background
 ==========
 
 In recent years, more and more Open Source Software (OSS) packages have become available to the weather radar community 
-(see `here <http://dx.doi.org/10.1175/BAMS-D-13-00240.1>`_). Still, we have to admit that some barriers prevent us 
+(see `here <https://doi.org/10.1175/BAMS-D-13-00240.1>`_). Still, we have to admit that some barriers prevent us 
 from tapping the full potential of OSS, such as nasty installation procedures, platform dependency and support issues, and steep learning curves.
 
 In order to address some of these issues, we present a community-based and open Virtual Machine (VM).

--- a/_sources/background.txt
+++ b/_sources/background.txt
@@ -2,7 +2,7 @@ Background
 ==========
 
 In recent years, more and more Open Source Software (OSS) packages have become available to the weather radar community 
-(see `here <http://dx.doi.org/10.1175/BAMS-D-13-00240.1>`_). Still, we have to admit that some barriers prevent us 
+(see `here <https://doi.org/10.1175/BAMS-D-13-00240.1>`_). Still, we have to admit that some barriers prevent us 
 from tapping the full potential of OSS, such as nasty installation procedures, platform dependency and support issues, and steep learning curves.
 
 In order to address some of these issues, we present a community-based and open Virtual Machine (VM).

--- a/_sources/index.rst.txt
+++ b/_sources/index.rst.txt
@@ -6,7 +6,7 @@ Towards Cross-Platform Weather Radar Science
 -------------------------------------------------------------
 
 In recent years, various Open Source Software (OSS) tools have become available 
-to the weather radar community (see `here <http://dx.doi.org/10.1175/BAMS-D-13-00240.1>`_).
+to the weather radar community (see `here <https://doi.org/10.1175/BAMS-D-13-00240.1>`_).
 
 On these pages, we present a Virtual Machine (VM) as a turn-key solution 
 to run and combine a number of weather radar software packages in a single environment: 

--- a/_sources/index.txt
+++ b/_sources/index.txt
@@ -6,7 +6,7 @@ Towards Cross-Platform Weather Radar Science
 -------------------------------------------------------------
 
 In recent years, various Open Source Software (OSS) tools have become available 
-to the weather radar community (see `here <http://dx.doi.org/10.1175/BAMS-D-13-00240.1>`_).
+to the weather radar community (see `here <https://doi.org/10.1175/BAMS-D-13-00240.1>`_).
 
 On these pages, we present a Virtual Machine (VM) as a turn-key solution 
 to run and combine a number of weather radar software packages in a single environment: 

--- a/background.html
+++ b/background.html
@@ -41,7 +41,7 @@
   <div class="section" id="background">
 <h1>Background<a class="headerlink" href="#background" title="Permalink to this headline">¶</a></h1>
 <p>In recent years, more and more Open Source Software (OSS) packages have become available to the weather radar community
-(see <a class="reference external" href="http://dx.doi.org/10.1175/BAMS-D-13-00240.1">here</a>). Still, we have to admit that some barriers prevent us
+(see <a class="reference external" href="https://doi.org/10.1175/BAMS-D-13-00240.1">here</a>). Still, we have to admit that some barriers prevent us
 from tapping the full potential of OSS, such as nasty installation procedures, platform dependency and support issues, and steep learning curves.</p>
 <p>In order to address some of these issues, we present a community-based and open Virtual Machine (VM).</p>
 <div class="section" id="turn-key-solution">

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 <div class="section" id="by-introducing-a-community-based-open-virtual-machine">
 <h2>…by introducing a community-based open Virtual Machine.<a class="headerlink" href="#by-introducing-a-community-based-open-virtual-machine" title="Permalink to this headline">¶</a></h2>
 <p>In recent years, various Open Source Software (OSS) tools have become available
-to the weather radar community (see <a class="reference external" href="http://dx.doi.org/10.1175/BAMS-D-13-00240.1">here</a>).</p>
+to the weather radar community (see <a class="reference external" href="https://doi.org/10.1175/BAMS-D-13-00240.1">here</a>).</p>
 <p>On these pages, we present a Virtual Machine (VM) as a turn-key solution
 to run and combine a number of weather radar software packages in a single environment:
 reliable, reproducible, scalable, and extendable.</p>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all static DOI links.

Cheers!